### PR TITLE
Add support for StrictHostKeyChecking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine
 
-RUN apk add --no-cache git openssh-client && \
-  echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+RUN apk add --no-cache git openssh-client
 
 ADD *.sh /
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ A GitHub Action for [mirroring a git repository](https://help.github.com/en/arti
 `SSH_PRIVATE_KEY`: Create a [SSH key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) **without** a passphrase which has access to both repositories. On GitHub you can add the public key as [a deploy key to the repository](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys). GitLab has also [deploy keys with write access](https://docs.gitlab.com/ee/user/project/deploy_keys/) and for any other services you may have to add the public key to your personal account.  
 Store the private key as [an encrypted secret](https://docs.github.com/en/actions/reference/encrypted-secrets) and use it in your workflow as seen in the example workflow below.
 
-If you added the private key in an [environment](https://docs.github.com/en/actions/reference/environments) make sure to [reference the environment name in your workflow](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idenvironment) otherwise the secret is not passed to the workflow.
+`SSH_KNOWN_HOSTS`: Known hosts as used in the `known_hosts` file. *StrictHostKeyChecking* is disabled in case the variable isn't available.
+
+If you added the private key or known hosts in an [environment](https://docs.github.com/en/actions/reference/environments) make sure to [reference the environment name in your workflow](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idenvironment) otherwise the secret is not passed to the workflow.
 
 ## Example workflow
 
@@ -37,6 +39,7 @@ jobs:
       - uses: wearerequired/git-mirror-action@v1
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         with:
           source-repo: "git@github.com:wearerequired/git-mirror-action.git"
           destination-repo: "git@bitbucket.org:wearerequired/git-mirror-action.git"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ then
   mkdir -p /root/.ssh
   echo "StrictHostKeyChecking yes" >> /etc/ssh/ssh_config
   echo "$SSH_KNOWN_HOSTS" > /root/.ssh/known_hosts
+  chmod 600 /root/.ssh/known_hosts
 else
   echo "WARNING: StrictHostKeyChecking disabled"
   echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,16 @@ then
   chmod 600 /root/.ssh/id_rsa
 fi
 
+if [[ -n "$SSH_KNOWN_HOSTS" ]]
+then
+  mkdir -p /root/.ssh
+  echo "StrictHostKeyChecking yes" >> /etc/ssh/ssh_config
+  echo "$SSH_KNOWN_HOSTS" > /root/.ssh/known_hosts
+else
+  echo "WARNING: StrictHostKeyChecking disabled"
+  echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
+fi
+
 mkdir -p ~/.ssh
 cp /root/.ssh/* ~/.ssh/ 2> /dev/null || true
 


### PR DESCRIPTION
Adds support for _StrictHostKeyChecking_ through `SSH_KNOWN_HOSTS` variable.

The `known_hosts` entries are passed by `SSH_KNOWN_HOSTS` (like the private key). If the variable isn't set, the checking is disabled (as at the moment).