### PR TITLE
Use safe directory name for source repo

### DIFF
--- a/git-mirror.sh
+++ b/git-mirror.sh
@@ -4,13 +4,14 @@ set -e
 
 SOURCE_REPO=$1
 DESTINATION_REPO=$2
+SOURCE_DIR=$(basename "$SOURCE_REPO")
 
 GIT_SSH_COMMAND="ssh -v"
 
 echo "SOURCE=$SOURCE_REPO"
 echo "DESTINATION=$DESTINATION_REPO"
 
-git clone --mirror "$SOURCE_REPO" && cd `basename "$SOURCE_REPO"`
+git clone --mirror "$SOURCE_REPO" "$SOURCE_DIR" && cd "$SOURCE_DIR"
 git remote set-url --push origin "$DESTINATION_REPO"
 git fetch -p origin
 # Exclude refs created by GitHub for pull request.


### PR DESCRIPTION
The cloned source repository directory may contain a `.git` suffix under some circumstances, even though the URL doesn't. This fails the `cd` after clone.

This PR ensures a safe directory name.