### PR TITLE
Add 'dry-run' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A GitHub Action for [mirroring a git repository](https://help.github.com/en/arti
 
 **Required** SSH URL of the destination repo.
 
+### `dry-run`
+
+**Optional** *(default: `false`)* Execute a dry run. All steps are executed, but no updates are pushed to the destination repo.
+
 ## Environment variables
 
 `SSH_PRIVATE_KEY`: Create a [SSH key](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) **without** a passphrase which has access to both repositories. On GitHub you can add the public key as [a deploy key to the repository](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys). GitLab has also [deploy keys with write access](https://docs.gitlab.com/ee/user/project/deploy_keys/) and for any other services you may have to add the public key to your personal account.  

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,14 @@ inputs:
     description: 'SSH URL of the destination repo.'
     required: true
     default: ''
+  dry-run:
+    description: 'Execute a dry run.'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.source-repo }}
     - ${{ inputs.destination-repo }}
+    - ${{ inputs.dry-run }}

--- a/git-mirror.sh
+++ b/git-mirror.sh
@@ -5,15 +5,24 @@ set -e
 SOURCE_REPO=$1
 DESTINATION_REPO=$2
 SOURCE_DIR=$(basename "$SOURCE_REPO")
+DRY_RUN=$3
 
 GIT_SSH_COMMAND="ssh -v"
 
 echo "SOURCE=$SOURCE_REPO"
 echo "DESTINATION=$DESTINATION_REPO"
+echo "DRY RUN=$DRY_RUN"
 
 git clone --mirror "$SOURCE_REPO" "$SOURCE_DIR" && cd "$SOURCE_DIR"
 git remote set-url --push origin "$DESTINATION_REPO"
 git fetch -p origin
 # Exclude refs created by GitHub for pull request.
 git for-each-ref --format 'delete %(refname)' refs/pull | git update-ref --stdin
-git push --mirror
+
+if [ "$DRY_RUN" = "true" ]
+then
+    echo "INFO: Dry Run, no data is pushed"
+    git push --mirror --dry-run
+else
+    git push --mirror
+fi


### PR DESCRIPTION
Adds an optional [dry run](https://git-scm.com/docs/git-push#Documentation/git-push.txt---dry-run) option to the final git push. This allows changes to the mirror configuration without altering the destination repository.

If enabled, there's an additional info message to indicate a dry run.